### PR TITLE
Set up Sentry

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -39,5 +39,10 @@
         s.parentNode.insertBefore(t, s);
       })();
     </script>
+    <script src="https://cdn.ravenjs.com/3.7.0/raven.min.js" crossorigin="anonymous"></script>
+    <script>
+      var dsn = 'https://dc6c3b9297d844618759c05d66a57234@sentry.io/104366'
+      Raven.config(dsn).install()
+    </script>
   </body>
 </html>


### PR DESCRIPTION
Imported the javascript client of Sentry through CDN, used my public
DNS key to configure Sentry. Before doing this I made a Sentry account,
set up a new project called ‘nova’ and copied the keys. For security, I
set the Allowed Domains in Client Security to
http://www.trevordmiller.com/nova/ so that keys aren’t used anywhere
(through Sentry dashboard).
I’m sure the project leader will want to move the Sentry project to his
own account, and in this case all he would have to do is swap DSN keys
to ones pointing to a project he created on Sentry.io
Next steps might include adding context via the Raven API, resulting in more insightful error messages. 