### PR TITLE
Add Sublime Text Color Scheme

### DIFF
--- a/src/data/plugins.js
+++ b/src/data/plugins.js
@@ -188,6 +188,25 @@ const plugins = [
       },
     ],
   },
+  {
+    title: 'Sublime Text',
+    icon: 'heart',
+    screenshot: 'https://github.com/driesvints/nova-sublime-text/raw/master/assets/screenshot.png?raw=true',
+    steps: [
+      'Copy the \'Nova.tmTheme\' to your \'Packages/Colorsublime-Themes\' directory',
+      'Change your \'color_scheme\' in your user preferences'
+    ],
+    links: [
+      {
+        title: 'Contributing instructions',
+        url: 'https://github.com/driesvints/nova-sublime-text/blob/master/CONTRIBUTING.md',
+      },
+      {
+        title: 'Source code',
+        url: 'https://github.com/driesvints/nova-sublime-text',
+      },
+    ],
+  },
 ]
 
 export default plugins


### PR DESCRIPTION
After some trial and error, I managed to set up a working build for a Sublime Text color scheme 😄 

The color scheme isn't perfect yet and probably needs some tweaking as well as adding more tags which should be colored. [Feel free to help out on improving it!](https://github.com/driesvints/nova-sublime-text)

I eventually also want to add a `Nove.sublime-theme` file for the UI of Sublime Text as well as put it up on Package control.

Btw, I don't really know how to add and icon for Sublime Text. Am I correct to guess that you have a paid pack for IcoMoon which contains the icon? If so: can you add an icon for Sublime Text to master so I can rebase? Perhaps also add one for PHPStorm as well because I'm planning to send a PR for that as well :)

Thanks and let me know what you think!